### PR TITLE
feat: Add SVG output format support for Mermaid diagrams

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,27 +1,27 @@
 # Mermaid MCP Server
 
-A Model Context Protocol (MCP) server that converts Mermaid diagrams to PNG images. This server allows AI assistants and other applications to generate visual diagrams from textual descriptions using the Mermaid markdown syntax.
+A Model Context Protocol (MCP) server that converts Mermaid diagrams to PNG images or SVG files. This server allows AI assistants and other applications to generate visual diagrams from textual descriptions using the Mermaid markdown syntax.
 
 ## Features
 
-- Converts Mermaid diagram code to PNG images
+- Converts Mermaid diagram code to PNG images or SVG files
 - Supports multiple diagram themes (default, forest, dark, neutral)
 - Customizable background colors
 - Uses Puppeteer for high-quality headless browser rendering
 - Implements the MCP protocol for seamless integration with AI assistants
-- Flexible output options: return images directly or save to disk
+- Flexible output options: return images/SVG directly or save to disk
 - Error handling with detailed error messages
 
 ## How It Works
 
-The server uses Puppeteer to launch a headless browser, render the Mermaid diagram to SVG, and capture a screenshot of the rendered diagram. The process involves:
+The server uses Puppeteer to launch a headless browser, render the Mermaid diagram to SVG, and optionally capture a screenshot of the rendered diagram. The process involves:
 
 1. Launching a headless browser instance
 2. Creating an HTML template with the Mermaid code
 3. Loading the Mermaid.js library
 4. Rendering the diagram to SVG
-5. Taking a screenshot of the rendered SVG as PNG
-6. Either returning the image directly or saving it to disk
+5. Either saving the SVG directly or taking a screenshot as PNG
+6. Either returning the image/SVG directly or saving it to disk
 
 ## Build
 
@@ -97,18 +97,19 @@ For Smithery users, the latest version should work without additional configurat
 
 The server exposes a single tool:
 
-- `generate`: Converts Mermaid diagram code to a PNG image
+- `generate`: Converts Mermaid diagram code to a PNG image or SVG file
   - Parameters:
     - `code`: The Mermaid diagram code to render
     - `theme`: (optional) Theme for the diagram. Options: "default", "forest", "dark", "neutral"
     - `backgroundColor`: (optional) Background color for the diagram, e.g. 'white', 'transparent', '#F0F0F0'
+    - `outputFormat`: (optional) Output format for the diagram. Options: "png", "svg" (defaults to "png")
     - `name`: Name for the generated file (required when CONTENT_IMAGE_SUPPORTED=false)
-    - `folder`: Absolute path to save the image to (required when CONTENT_IMAGE_SUPPORTED=false)
+    - `folder`: Absolute path to save the image/SVG to (required when CONTENT_IMAGE_SUPPORTED=false)
 
 The behavior of the `generate` tool depends on the `CONTENT_IMAGE_SUPPORTED` environment variable:
 
-- When `CONTENT_IMAGE_SUPPORTED=true` (default): The tool returns the image directly in the response
-- When `CONTENT_IMAGE_SUPPORTED=false`: The tool saves the image to the specified folder and returns the file path
+- When `CONTENT_IMAGE_SUPPORTED=true` (default): The tool returns the image/SVG directly in the response
+- When `CONTENT_IMAGE_SUPPORTED=false`: The tool saves the image/SVG to the specified folder and returns the file path
 
 ## Environment Variables
 
@@ -141,11 +142,23 @@ The behavior of the `generate` tool depends on the `CONTENT_IMAGE_SUPPORTED` env
 ### Saving to Disk (when CONTENT_IMAGE_SUPPORTED=false)
 
 ```javascript
-// Generate a class diagram and save it to disk
+// Generate a class diagram and save it to disk as PNG
 {
   "code": "classDiagram\n    Class01 <|-- AveryLongClass\n    Class03 *-- Class04\n    Class05 o-- Class06",
   "theme": "dark",
   "name": "class_diagram",
+  "folder": "/path/to/diagrams"
+}
+```
+
+### Generating SVG Output
+
+```javascript
+// Generate a state diagram as SVG
+{
+  "code": "stateDiagram-v2\n    [*] --> Still\n    Still --> [*]\n    Still --> Moving\n    Moving --> Still\n    Moving --> Crash\n    Crash --> [*]",
+  "outputFormat": "svg",
+  "name": "state_diagram",
   "folder": "/path/to/diagrams"
 }
 ```

--- a/README.md
+++ b/README.md
@@ -1,6 +1,5 @@
 # Mermaid MCP Server
 
-
 A Model Context Protocol (MCP) server that converts Mermaid diagrams to PNG images. This server allows AI assistants and other applications to generate visual diagrams from textual descriptions using the Mermaid markdown syntax.
 
 ## Features
@@ -35,12 +34,12 @@ npx tsc
 ### Use with Claude desktop
 
 ```json
-"mcpServers": {
-  "mermaid": {
-    "command": "npx",
-    "args": [
-      "-y @peng-shawn/mermaid-mcp-server"
-    ]
+{
+  "mcpServers": {
+    "mermaid": {
+      "command": "npx",
+      "args": ["-y", "@peng-shawn/mermaid-mcp-server"]
+    }
   }
 }
 ```
@@ -81,11 +80,13 @@ When running in Docker containers (including via Smithery), you may need to hand
 2. If you encounter browser-related errors, you have two options:
 
    **Option 1: During Docker image build:**
+
    - Set `PUPPETEER_SKIP_CHROMIUM_DOWNLOAD=true` when installing Puppeteer
    - Install Chrome/Chromium in your Docker container
    - Set `PUPPETEER_EXECUTABLE_PATH` at runtime to point to the Chrome installation
 
    **Option 2: Use Puppeteer's bundled Chrome:**
+
    - Ensure your Docker container has the necessary dependencies for Chrome
    - No need to set `PUPPETEER_SKIP_CHROMIUM_DOWNLOAD`
    - The code will use the bundled browser automatically
@@ -159,7 +160,6 @@ Yes, but it doesn't support the `theme` and `backgroundColor` options. Plus, hav
 
 Cursor doesn't support inline images in responses yet.
 
-
 ## Publishing
 
 This project uses GitHub Actions to automate the publishing process to npm.
@@ -168,15 +168,17 @@ This project uses GitHub Actions to automate the publishing process to npm.
 
 1. Make sure all your changes are committed and pushed
 2. Run the release script with either a specific version number or a semantic version increment:
+
    ```bash
    # Using a specific version number
    npm run release 0.1.4
-   
+
    # Using semantic version increments
    npm run release patch  # Increments the patch version (e.g., 0.1.3 → 0.1.4)
    npm run release minor  # Increments the minor version (e.g., 0.1.3 → 0.2.0)
    npm run release major  # Increments the major version (e.g., 0.1.3 → 1.0.0)
    ```
+
 3. The script will:
    - Validate the version format or semantic increment
    - Check if you're on the main branch
@@ -199,6 +201,7 @@ This project uses GitHub Actions to automate the publishing process to npm.
    - Publish to npm with the version from the tag
 
 Note: You need to set up the `NPM_TOKEN` secret in your GitHub repository settings. To do this:
+
 1. Generate an npm access token with publish permissions
 2. Go to your GitHub repository → Settings → Secrets and variables → Actions
 3. Create a new repository secret named `NPM_TOKEN` with your npm token as the value
@@ -210,7 +213,6 @@ Note: You need to set up the `NPM_TOKEN` secret in your GitHub repository settin
 <a href="https://glama.ai/mcp/servers/lzjlbitkzr">
   <img width="380" height="200" src="https://glama.ai/mcp/servers/lzjlbitkzr/badge" alt="mermaid-mcp-server MCP server" />
 </a>
-
 
 ## License
 

--- a/index.ts
+++ b/index.ts
@@ -1,10 +1,10 @@
 #!/usr/bin/env node
 
-import puppeteer from 'puppeteer';
-import path from 'path';
-import url from 'url';
-import fs from 'fs';
-import { resolve } from 'import-meta-resolve';
+import puppeteer from "puppeteer";
+import path from "path";
+import url from "url";
+import fs from "fs";
+import { resolve } from "import-meta-resolve";
 import { Server } from "@modelcontextprotocol/sdk/server/index.js";
 import { StdioServerTransport } from "@modelcontextprotocol/sdk/server/stdio.js";
 import {
@@ -15,9 +15,9 @@ import {
 
 /**
  * Mermaid MCP Server
- * 
+ *
  * This server provides a tool to render Mermaid diagrams as PNG images.
- * 
+ *
  * Environment Variables:
  * - MERMAID_LOG_VERBOSITY: Controls the verbosity of logging (default: 2)
  *   0 = EMERGENCY - Only the most critical errors
@@ -28,20 +28,20 @@ import {
  *   5 = DEBUG - Debug-level messages
  * - CONTENT_IMAGE_SUPPORTED: Controls whether images can be returned directly in the response (default: true)
  *   When set to 'false', the 'name' and 'folder' parameters become mandatory, and all images must be saved to disk.
- * 
+ *
  * Example:
  *   MERMAID_LOG_VERBOSITY=2 node index.js  # Only show ERROR and more severe logs (default)
  *   MERMAID_LOG_VERBOSITY=4 node index.js  # Show INFO and more severe logs
  *   MERMAID_LOG_VERBOSITY=5 node index.js  # Show DEBUG and more severe logs
  *   CONTENT_IMAGE_SUPPORTED=false node index.js  # Require all images to be saved to disk
- * 
+ *
  * Tool Parameters:
  * - code: The mermaid markdown to generate an image from (required)
  * - theme: Theme for the diagram (optional, one of: "default", "forest", "dark", "neutral")
  * - backgroundColor: Background color for the diagram (optional, e.g., "white", "transparent", "#F0F0F0")
  * - name: Name for the generated file (required when saving to folder or when CONTENT_IMAGE_SUPPORTED=false)
  * - folder: Folder path to save the image to (optional, but required when CONTENT_IMAGE_SUPPORTED=false)
- * 
+ *
  * File Saving Behavior:
  * - When 'folder' is specified, the image will be saved to disk instead of returned in the response
  * - The 'name' parameter is required when 'folder' is specified
@@ -50,7 +50,7 @@ import {
  */
 
 // __dirname is not available in ESM modules by default
-const __dirname = url.fileURLToPath(new URL('.', import.meta.url));
+const __dirname = url.fileURLToPath(new URL(".", import.meta.url));
 
 // Define log levels with numeric values for comparison
 enum LogLevel {
@@ -63,23 +63,31 @@ enum LogLevel {
 }
 
 // Get verbosity level from environment variable, default to INFO (4)
-const LOG_VERBOSITY = process.env.MERMAID_LOG_VERBOSITY 
-  ? parseInt(process.env.MERMAID_LOG_VERBOSITY, 10) 
+const LOG_VERBOSITY = process.env.MERMAID_LOG_VERBOSITY
+  ? parseInt(process.env.MERMAID_LOG_VERBOSITY, 10)
   : LogLevel.ERROR;
 
 // Check if content images are supported (default: true)
-const CONTENT_IMAGE_SUPPORTED = process.env.CONTENT_IMAGE_SUPPORTED !== 'false';
+const CONTENT_IMAGE_SUPPORTED = process.env.CONTENT_IMAGE_SUPPORTED !== "false";
 
 // Convert LogLevel to MCP log level string
-function getMcpLogLevel(level: LogLevel): "error" | "info" | "debug" | "warning" | "critical" | "emergency" {
+function getMcpLogLevel(
+  level: LogLevel
+): "error" | "info" | "debug" | "warning" | "critical" | "emergency" {
   switch (level) {
-    case LogLevel.EMERGENCY: return "emergency";
-    case LogLevel.CRITICAL: return "critical";
-    case LogLevel.ERROR: return "error";
-    case LogLevel.WARNING: return "warning";
-    case LogLevel.DEBUG: return "debug";
-    case LogLevel.INFO: 
-    default: return "info";
+    case LogLevel.EMERGENCY:
+      return "emergency";
+    case LogLevel.CRITICAL:
+      return "critical";
+    case LogLevel.ERROR:
+      return "error";
+    case LogLevel.WARNING:
+      return "warning";
+    case LogLevel.DEBUG:
+      return "debug";
+    case LogLevel.INFO:
+    default:
+      return "info";
   }
 }
 
@@ -88,12 +96,12 @@ function log(level: LogLevel, message: string) {
   if (level <= LOG_VERBOSITY) {
     // Get the appropriate MCP log level
     const mcpLevel = getMcpLogLevel(level);
-    
+
     server.sendLoggingMessage({
       level: mcpLevel,
-      data: message
+      data: message,
     });
-    
+
     // Only console.error is consumed by MCP inspector
     console.error(`${LogLevel[level]} - ${message}`);
   }
@@ -108,28 +116,33 @@ const GENERATE_TOOL: Tool = {
     properties: {
       code: {
         type: "string",
-        description: "The mermaid markdown to generate an image from"
+        description: "The mermaid markdown to generate an image from",
       },
       theme: {
         type: "string",
         enum: ["default", "forest", "dark", "neutral"],
-        description: "Theme for the diagram (optional)"
+        description: "Theme for the diagram (optional)",
       },
       backgroundColor: {
         type: "string",
-        description: "Background color for the diagram, e.g. 'white', 'transparent', '#F0F0F0' (optional)"
+        description:
+          "Background color for the diagram, e.g. 'white', 'transparent', '#F0F0F0' (optional)",
       },
       name: {
         type: "string",
-        description: CONTENT_IMAGE_SUPPORTED ? "Name of the diagram (optional)" : "Name for the generated file (required)"
+        description: CONTENT_IMAGE_SUPPORTED
+          ? "Name of the diagram (optional)"
+          : "Name for the generated file (required)",
       },
       folder: {
         type: "string",
-        description: CONTENT_IMAGE_SUPPORTED ? "Absolute path to save the image to (optional)" : "Absolute path to save the image to (required)"
-      }
+        description: CONTENT_IMAGE_SUPPORTED
+          ? "Absolute path to save the image to (optional)"
+          : "Absolute path to save the image to (required)",
+      },
     },
-    required: CONTENT_IMAGE_SUPPORTED ? ["code"] : ["code", "name", "folder"]
-  }
+    required: CONTENT_IMAGE_SUPPORTED ? ["code"] : ["code", "name", "folder"],
+  },
 };
 
 // Server implementation
@@ -141,65 +154,72 @@ const server = new Server(
   {
     capabilities: {
       tools: {},
-      logging: {}
+      logging: {},
     },
   }
 );
 
 function isGenerateArgs(args: unknown): args is {
   code: string;
-  theme?: 'default' | 'forest' | 'dark' | 'neutral';
+  theme?: "default" | "forest" | "dark" | "neutral";
   backgroundColor?: string;
   name?: string;
   folder?: string;
 } {
   return (
-    typeof args === 'object' &&
+    typeof args === "object" &&
     args !== null &&
-    'code' in args &&
-    typeof (args as any).code === 'string' &&
-    (!(args as any).theme || ['default', 'forest', 'dark', 'neutral'].includes((args as any).theme)) &&
-    (!(args as any).backgroundColor || typeof (args as any).backgroundColor === 'string') &&
-    (!(args as any).name || typeof (args as any).name === 'string') &&
-    (!(args as any).folder || typeof (args as any).folder === 'string')
+    "code" in args &&
+    typeof (args as any).code === "string" &&
+    (!(args as any).theme ||
+      ["default", "forest", "dark", "neutral"].includes((args as any).theme)) &&
+    (!(args as any).backgroundColor ||
+      typeof (args as any).backgroundColor === "string") &&
+    (!(args as any).name || typeof (args as any).name === "string") &&
+    (!(args as any).folder || typeof (args as any).folder === "string")
   );
 }
 
-async function renderMermaidPng(code: string, config: {
-  theme?: 'default' | 'forest' | 'dark' | 'neutral';
-  backgroundColor?: string;
-} = {}): Promise<string> {
+async function renderMermaidPng(
+  code: string,
+  config: {
+    theme?: "default" | "forest" | "dark" | "neutral";
+    backgroundColor?: string;
+  } = {}
+): Promise<string> {
   log(LogLevel.INFO, "Launching Puppeteer");
   log(LogLevel.DEBUG, `Rendering with config: ${JSON.stringify(config)}`);
-  
+
   // Resolve the path to the local mermaid.js file
-  const distPath = path.dirname(url.fileURLToPath(resolve('mermaid', import.meta.url)));
-  const mermaidPath = path.resolve(distPath, 'mermaid.min.js');
+  const distPath = path.dirname(
+    url.fileURLToPath(resolve("mermaid", import.meta.url))
+  );
+  const mermaidPath = path.resolve(distPath, "mermaid.min.js");
   log(LogLevel.DEBUG, `Using Mermaid from: ${mermaidPath}`);
 
   const browser = await puppeteer.launch({
     headless: true,
     // Use the bundled browser instead of looking for Chrome on the system
     executablePath: process.env.PUPPETEER_EXECUTABLE_PATH || undefined,
-    args: ['--no-sandbox', '--disable-setuid-sandbox'],
+    args: ["--no-sandbox", "--disable-setuid-sandbox"],
   });
-  
+
   // Declare page outside try block so it's accessible in catch and finally
   let page: puppeteer.Page | null = null;
   // Store console messages for error reporting
   const consoleMessages: string[] = [];
-  
+
   try {
     page = await browser.newPage();
     log(LogLevel.DEBUG, "Browser page created");
-    
+
     // Capture browser console messages for better error reporting
-    page.on('console', (msg) => {
+    page.on("console", (msg) => {
       const text = msg.text();
       consoleMessages.push(text);
       log(LogLevel.DEBUG, text);
     });
-    
+
     // Create a simple HTML template without the CDN reference
     const htmlContent = `
     <!DOCTYPE html>
@@ -208,7 +228,7 @@ async function renderMermaidPng(code: string, config: {
       <title>Mermaid Renderer</title>
       <style>
         body { 
-          background: ${config.backgroundColor || 'white'};
+          background: ${config.backgroundColor || "white"};
           margin: 0;
           padding: 0;
         }
@@ -225,107 +245,127 @@ async function renderMermaidPng(code: string, config: {
     `;
     // 注意：要在 page.goto() **之前** 设置
     await page.setViewport({
-      width: 1200,            // 视口尺寸保持和原来相同即可
+      width: 1200, // 视口尺寸保持和原来相同即可
       height: 800,
-      deviceScaleFactor: 3    // 2~4 皆可，越大 PNG 越清晰也越大
+      deviceScaleFactor: 3, // 2~4 皆可，越大 PNG 越清晰也越大
     });
-    
+
     // Write the HTML to a temporary file
-    const tempHtmlPath = path.join(__dirname, 'temp-mermaid.html');
+    const tempHtmlPath = path.join(__dirname, "temp-mermaid.html");
     fs.writeFileSync(tempHtmlPath, htmlContent);
-    
+
     log(LogLevel.INFO, `Rendering mermaid code: ${code.substring(0, 50)}...`);
     log(LogLevel.DEBUG, `Full mermaid code: ${code}`);
-    
+
     // Navigate to the HTML file
     await page.goto(`file://${tempHtmlPath}`);
     log(LogLevel.DEBUG, "Navigated to HTML template");
-    
+
     // Add the mermaid script to the page
     await page.addScriptTag({ path: mermaidPath });
     log(LogLevel.DEBUG, "Added Mermaid script to page");
-    
+
     // Render the mermaid diagram using a more robust approach similar to the CLI
     log(LogLevel.DEBUG, "Starting Mermaid rendering in browser");
-    const screenshot = await page.$eval('#container', async (container, mermaidCode, mermaidConfig) => {
-      try {
-        // @ts-ignore - mermaid is loaded by the script tag
-        window.mermaid.initialize({
-          startOnLoad: false,
-          theme: mermaidConfig.theme || 'default',
-          securityLevel: 'loose',
-          logLevel: 5
-        });
-        
-        // This will throw an error if the mermaid syntax is invalid
-        // @ts-ignore - mermaid is loaded by the script tag
-        const { svg: svgText } = await window.mermaid.render('mermaid-svg', mermaidCode, container);
-        container.innerHTML = svgText;
-        
-        const svg = container.querySelector('svg');
-        if (!svg) {
-          throw new Error('SVG element not found after rendering');
+    const screenshot = await page.$eval(
+      "#container",
+      async (container, mermaidCode, mermaidConfig) => {
+        try {
+          // @ts-ignore - mermaid is loaded by the script tag
+          window.mermaid.initialize({
+            startOnLoad: false,
+            theme: mermaidConfig.theme || "default",
+            securityLevel: "loose",
+            logLevel: 5,
+          });
+
+          // This will throw an error if the mermaid syntax is invalid
+          // @ts-ignore - mermaid is loaded by the script tag
+          const { svg: svgText } = await window.mermaid.render(
+            "mermaid-svg",
+            mermaidCode,
+            container
+          );
+          container.innerHTML = svgText;
+
+          const svg = container.querySelector("svg");
+          if (!svg) {
+            throw new Error("SVG element not found after rendering");
+          }
+
+          // Apply any necessary styling to the SVG
+          svg.style.backgroundColor = mermaidConfig.backgroundColor || "white";
+
+          // Return the dimensions for screenshot
+          const rect = svg.getBoundingClientRect();
+          return {
+            width: Math.ceil(rect.width),
+            height: Math.ceil(rect.height),
+            success: true,
+          };
+        } catch (error) {
+          // Return the error to be handled outside
+          return {
+            success: false,
+            error: error instanceof Error ? error.message : String(error),
+          };
         }
-        
-        // Apply any necessary styling to the SVG
-        svg.style.backgroundColor = mermaidConfig.backgroundColor || 'white';
-        
-        // Return the dimensions for screenshot
-        const rect = svg.getBoundingClientRect();
-        return {
-          width: Math.ceil(rect.width),
-          height: Math.ceil(rect.height),
-          success: true
-        };
-      } catch (error) {
-        // Return the error to be handled outside
-        return {
-          success: false,
-          error: error instanceof Error ? error.message : String(error)
-        };
-      }
-    }, code, { theme: config.theme, backgroundColor: config.backgroundColor });
-    
+      },
+      code,
+      { theme: config.theme, backgroundColor: config.backgroundColor }
+    );
+
     // Check if rendering was successful
     if (!screenshot.success) {
-      log(LogLevel.ERROR, `Mermaid rendering failed in browser: ${screenshot.error}`);
+      log(
+        LogLevel.ERROR,
+        `Mermaid rendering failed in browser: ${screenshot.error}`
+      );
       throw new Error(`Mermaid rendering failed: ${screenshot.error}`);
     }
-    
+
     log(LogLevel.DEBUG, "Mermaid rendered successfully in browser");
-    
+
     // Take a screenshot of the SVG
-    const svgElement = await page.$('#container svg');
+    const svgElement = await page.$("#container svg");
     if (!svgElement) {
       log(LogLevel.ERROR, "SVG element not found after successful rendering");
-      throw new Error('SVG element not found');
+      throw new Error("SVG element not found");
     }
-    
+
     log(LogLevel.DEBUG, "Taking screenshot of SVG");
     // Take a screenshot with the correct dimensions
     const base64Image = await svgElement.screenshot({
       omitBackground: false,
-      type: 'png',
-      encoding: 'base64'
+      type: "png",
+      encoding: "base64",
     });
-    
+
     // Clean up the temporary file
     fs.unlinkSync(tempHtmlPath);
     log(LogLevel.DEBUG, "Temporary HTML file cleaned up");
-    
+
     log(LogLevel.INFO, "Mermaid rendered successfully");
-    
+
     return base64Image;
   } catch (error) {
-    log(LogLevel.ERROR, `Error in renderMermaidPng: ${error instanceof Error ? error.message : String(error)}`);
-    log(LogLevel.ERROR, `Error stack: ${error instanceof Error ? error.stack : 'No stack trace'}`);
-    
+    log(
+      LogLevel.ERROR,
+      `Error in renderMermaidPng: ${
+        error instanceof Error ? error.message : String(error)
+      }`
+    );
+    log(
+      LogLevel.ERROR,
+      `Error stack: ${error instanceof Error ? error.stack : "No stack trace"}`
+    );
+
     // Include console messages in the error for better debugging
     if (page && page.isClosed() === false) {
       log(LogLevel.ERROR, "Browser console messages:");
-      consoleMessages.forEach(msg => log(LogLevel.ERROR, `  ${msg}`));
+      consoleMessages.forEach((msg) => log(LogLevel.ERROR, `  ${msg}`));
     }
-    
+
     throw error;
   } finally {
     await browser.close();
@@ -335,61 +375,66 @@ async function renderMermaidPng(code: string, config: {
 
 /**
  * Saves a generated Mermaid diagram to a file
- * 
+ *
  * @param base64Image - The base64-encoded PNG image
  * @param name - The name to use for the file (without extension)
  * @param folder - The folder to save the file in
  * @returns The full path to the saved file
  */
-async function saveMermaidImageToFile(base64Image: string, name: string, folder: string): Promise<string> {
+async function saveMermaidImageToFile(
+  base64Image: string,
+  name: string,
+  folder: string
+): Promise<string> {
   // Create the folder if it doesn't exist
   if (!fs.existsSync(folder)) {
     log(LogLevel.INFO, `Creating folder: ${folder}`);
     fs.mkdirSync(folder, { recursive: true });
   }
-  
+
   // Generate a filename, adding timestamp if file already exists
   let filename = `${name}.png`;
   const filePath = path.join(folder, filename);
-  
+
   if (fs.existsSync(filePath)) {
-    const timestamp = new Date().toISOString().replace(/[:.]/g, '-');
+    const timestamp = new Date().toISOString().replace(/[:.]/g, "-");
     filename = `${name}-${timestamp}.png`;
     log(LogLevel.INFO, `File already exists, using filename: ${filename}`);
   }
-  
+
   // Save the image to the file
-  const imageBuffer = Buffer.from(base64Image, 'base64');
+  const imageBuffer = Buffer.from(base64Image, "base64");
   const fullPath = path.join(folder, filename);
   fs.writeFileSync(fullPath, imageBuffer);
-  
+
   log(LogLevel.INFO, `Image saved to: ${fullPath}`);
   return fullPath;
 }
 
 /**
  * Handles Mermaid syntax errors and other errors
- * 
+ *
  * @param error - The error that occurred
  * @returns A response object with the error message
  */
-function handleMermaidError(error: unknown): { 
-  content: Array<{ type: "text"; text: string }>, 
-  isError: boolean 
+function handleMermaidError(error: unknown): {
+  content: Array<{ type: "text"; text: string }>;
+  isError: boolean;
 } {
   const errorMessage = error instanceof Error ? error.message : String(error);
-  const isSyntaxError = errorMessage.includes("Syntax error") || 
-                        errorMessage.includes("Parse error") || 
-                        errorMessage.includes("Mermaid rendering failed");
-  
+  const isSyntaxError =
+    errorMessage.includes("Syntax error") ||
+    errorMessage.includes("Parse error") ||
+    errorMessage.includes("Mermaid rendering failed");
+
   return {
     content: [
       {
         type: "text",
-        text: isSyntaxError 
-          ? `Mermaid syntax error: ${errorMessage}\n\nPlease check your diagram syntax.` 
+        text: isSyntaxError
+          ? `Mermaid syntax error: ${errorMessage}\n\nPlease check your diagram syntax.`
           : `Error generating diagram: ${errorMessage}`,
-      }
+      },
     ],
     isError: true,
   };
@@ -397,69 +442,86 @@ function handleMermaidError(error: unknown): {
 
 /**
  * Processes a generate request to create a Mermaid diagram
- * 
+ *
  * @param args - The arguments for the generate request
  * @returns A response object with the generated image or file path
  */
 async function processGenerateRequest(args: {
   code: string;
-  theme?: 'default' | 'forest' | 'dark' | 'neutral';
+  theme?: "default" | "forest" | "dark" | "neutral";
   backgroundColor?: string;
   name?: string;
   folder?: string;
-}): Promise<{ 
+}): Promise<{
   content: Array<
     | { type: "text"; text: string }
     | { type: "image"; data: string; mimeType: string }
-  >, 
-  isError: boolean 
+  >;
+  isError: boolean;
 }> {
   try {
     const base64Image = await renderMermaidPng(args.code, {
       theme: args.theme,
-      backgroundColor: args.backgroundColor
+      backgroundColor: args.backgroundColor,
     });
-    
+
     // Check if we need to save the image to a folder
     if (!CONTENT_IMAGE_SUPPORTED) {
       if (!args.folder) {
-        throw new Error("Folder parameter is required when CONTENT_IMAGE_SUPPORTED is false");
+        throw new Error(
+          "Folder parameter is required when CONTENT_IMAGE_SUPPORTED is false"
+        );
       }
 
       // Save the image to a file
-      const fullPath = await saveMermaidImageToFile(base64Image, args.name!, args.folder!);
-      
+      const fullPath = await saveMermaidImageToFile(
+        base64Image,
+        args.name!,
+        args.folder!
+      );
+
       return {
         content: [
           {
             type: "text",
             text: `Image saved to: ${fullPath}`,
-          }
+          },
         ],
         isError: false,
       };
     }
-    
+
     // If folder is provided and CONTENT_IMAGE_SUPPORTED is true, save the image to the folder
     // but also return the image in the response
     let savedMessage = "";
     if (args.folder && args.name) {
       try {
-        const fullPath = await saveMermaidImageToFile(base64Image, args.name, args.folder);
+        const fullPath = await saveMermaidImageToFile(
+          base64Image,
+          args.name,
+          args.folder
+        );
         savedMessage = `Image also saved to: ${fullPath}`;
         log(LogLevel.INFO, savedMessage);
       } catch (saveError) {
-        log(LogLevel.ERROR, `Failed to save image to folder: ${(saveError as Error).message}`);
-        savedMessage = `Note: Failed to save image to folder: ${(saveError as Error).message}`;
+        log(
+          LogLevel.ERROR,
+          `Failed to save image to folder: ${(saveError as Error).message}`
+        );
+        savedMessage = `Note: Failed to save image to folder: ${
+          (saveError as Error).message
+        }`;
       }
     }
-    
+
     // Return the image in the response
     return {
       content: [
         {
           type: "text",
-          text: savedMessage ? `Here is the generated image. ${savedMessage}` : "Here is the generated image",
+          text: savedMessage
+            ? `Here is the generated image. ${savedMessage}`
+            : "Here is the generated image",
         },
         {
           type: "image",
@@ -488,14 +550,17 @@ server.setRequestHandler(CallToolRequestSchema, async (request) => {
       throw new Error("No arguments provided");
     }
 
-    log(LogLevel.INFO, `Received request: ${name} with args: ${JSON.stringify(args)}`);
+    log(
+      LogLevel.INFO,
+      `Received request: ${name} with args: ${JSON.stringify(args)}`
+    );
 
     if (name === "generate") {
       log(LogLevel.INFO, "Rendering Mermaid PNG");
       if (!isGenerateArgs(args)) {
         throw new Error("Invalid arguments for generate");
       }
-      
+
       // Process the generate request
       return await processGenerateRequest(args);
     }
@@ -509,7 +574,9 @@ server.setRequestHandler(CallToolRequestSchema, async (request) => {
       content: [
         {
           type: "text",
-          text: `Error: ${error instanceof Error ? error.message : String(error)}`,
+          text: `Error: ${
+            error instanceof Error ? error.message : String(error)
+          }`,
         },
       ],
       isError: true,
@@ -524,6 +591,11 @@ async function runServer() {
 }
 
 runServer().catch((error) => {
-  log(LogLevel.CRITICAL, `Fatal error running server: ${error instanceof Error ? error.message : String(error)}`);
+  log(
+    LogLevel.CRITICAL,
+    `Fatal error running server: ${
+      error instanceof Error ? error.message : String(error)
+    }`
+  );
   process.exit(1);
 });

--- a/package-lock.json
+++ b/package-lock.json
@@ -3205,9 +3205,9 @@
       "license": "MIT"
     },
     "node_modules/tar-fs": {
-      "version": "3.0.8",
-      "resolved": "https://registry.npmjs.org/tar-fs/-/tar-fs-3.0.8.tgz",
-      "integrity": "sha512-ZoROL70jptorGAlgAYiLoBLItEKw/fUxg9BSYK/dF/GAGYFJOJJJMvjPAKDJraCXFwadD456FCuvLWgfhMsPwg==",
+      "version": "3.0.10",
+      "resolved": "https://registry.npmjs.org/tar-fs/-/tar-fs-3.0.10.tgz",
+      "integrity": "sha512-C1SwlQGNLe/jPNqapK8epDsXME7CAJR5RL3GcE6KWx1d9OUByzoHVcbu1VPI8tevg9H8Alae0AApHHFGzrD5zA==",
       "license": "MIT",
       "dependencies": {
         "pump": "^3.0.0",


### PR DESCRIPTION
  ## Summary

  This PR enhances the mermaid-mcp-server by adding support for SVG output format alongside the existing PNG
  format. Users can now choose between PNG and SVG when generating Mermaid diagrams, providing better scalability
  and smaller file sizes for vector-based diagrams.

  ## Changes

  - Added outputFormat parameter: The generate tool now accepts an optional outputFormat parameter that supports       
  "png" or "svg" (defaults to "png" for backward compatibility)
  - Refactored rendering function: Renamed renderMermaidPng to renderMermaid and extended it to handle both PNG        
  and SVG output formats
  - Added SVG file saving: Implemented saveMermaidSvgToFile function to save SVG files to disk with consistent
  naming conventions
  - Updated request processing: Modified processGenerateRequest to handle the new SVG output format
  - Documentation updates: Enhanced README with examples and explanations of the new SVG functionality

 ##  Features

  Users can now:
  - Generate Mermaid diagrams as SVG files for better scalability
  - Save SVG files to disk using the same naming pattern as PNG files
  - Receive SVG content directly in the response when CONTENT_IMAGE_SUPPORTED=true
  - Choose output format flexibly while maintaining backward compatibility

 ##  Example Usage

  {
    "code": "graph TD; A-->B;",
    "outputFormat": "svg"
  }

  ## Breaking Changes

  None - the changes are fully backward compatible. The outputFormat parameter is optional and defaults to "png".      
  